### PR TITLE
Update ObjectIdentifierValue.java

### DIFF
--- a/src/java/net/percederberg/mibble/value/ObjectIdentifierValue.java
+++ b/src/java/net/percederberg/mibble/value/ObjectIdentifierValue.java
@@ -240,7 +240,7 @@ public class ObjectIdentifierValue extends MibValue {
                 getParent().children.remove(this);
                 parent = null;
             }
-            children = null;
+            children = new ArrayList<ObjectIdentifierValue>()
         }
 
         // Clear other value data
@@ -697,7 +697,7 @@ public class ObjectIdentifierValue extends MibValue {
             child.parent = this;
             addChild(log, fileRef, child);
         }
-        parent.children = null;
+        parent.children = new ArrayList<ObjectIdentifierValue>();
     }
 
     /**


### PR DESCRIPTION
* Removed the possibility of a NullPointerException when accessing the ObjectIdentifierValues children.

A NullPointerException was thrown when parsing a MIB with a missing import.  Not sure exactly why a missing import resulted in an ObjectIdentifierValue having a null value for it's children but changing the children property to be an empty list instead of null when cleared fixed the issue.

15:48:54.981 [main] ERROR u.c.b.m.parser.MibbleMibParser - Parsing failed. File [ADSL-LINE-MIB]
15:48:54.977 [main] ERROR u.c.b.m.parser.MibbleMibParser - An unexpected exception occurred parsing the MIB.
java.lang.NullPointerException: null
	at net.percederberg.mibble.value.ObjectIdentifierValue.addChild(ObjectIdentifierValue.java:642) ~[mibble-parser-2.10.alpha5.jar:na]
	at net.percederberg.mibble.value.ObjectIdentifierValue.initialize(ObjectIdentifierValue.java:182) ~[mibble-parser-2.10.alpha5.jar:na]
	at net.percederberg.mibble.value.ObjectIdentifierValue.initialize(ObjectIdentifierValue.java:178) ~[mibble-parser-2.10.alpha5.jar:na]
	at net.percederberg.mibble.MibValueSymbol.initialize(MibValueSymbol.java:100) ~[mibble-parser-2.10.alpha5.jar:na]
	at net.percederberg.mibble.Mib.validate(Mib.java:186) ~[mibble-parser-2.10.alpha5.jar:na]
	at net.percederberg.mibble.MibLoader.loadQueue(MibLoader.java:738) ~[mibble-parser-2.10.alpha5.jar:na]
	at net.percederberg.mibble.MibLoader.load(MibLoader.java:555) ~[mibble-parser-2.10.alpha5.jar:na]
	at net.percederberg.mibble.MibLoader.load(MibLoader.java:535) ~[mibble-parser-2.10.alpha5.jar:na]