### PR TITLE
Update MibImporter to return when mib is null.

### DIFF
--- a/src/java/net/percederberg/mibble/MibImport.java
+++ b/src/java/net/percederberg/mibble/MibImport.java
@@ -70,17 +70,14 @@ public class MibImport implements MibContext {
      * symbols.  This method will be called by the MIB loader.
      *
      * @param log            the MIB loader log
-     *
-     * @throws MibException if an error was encountered during the
-     *             initialization
      */
     public void initialize(MibLoaderLog log) throws MibException {
         mib = loader.getMib(name);
         if (mib == null) {
-
             String msg = "couldn't find referenced MIB '" + name + "', " +
                          "skipping import of " + symbols.size() + " symbols";
             log.addWarning(fileRef, msg);
+            return;
         }
         if (symbols != null) {
             for (String sym : symbols) {


### PR DESCRIPTION
Reson for update: 
We update 2.10 and had NullPointerException when mib is null. Then the mib loader stops. 
Also update javadoc since we don't throw MibException now.